### PR TITLE
feat: add collapsible header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ export default function App() {
   const [compact, setCompact] = useState(false);
   const [q, setQ] = useState("");
   const [favOnly, setFavOnly] = useState(false);
+  const [isHeaderOpen, setHeaderOpen] = useState(true);
   const [favs, setFavs] = useState(() => {
     try { return new Set(JSON.parse(localStorage.getItem("cr-favs") || "[]")); }
     catch { return new Set(); }
@@ -54,11 +55,14 @@ export default function App() {
     <>
       <AnimatedBackground />
       <div className="container">
-        <header className="site-header">
+        <header className={`site-header ${isHeaderOpen ? "" : "collapsed"}`}>
           <div className="site-header__titles">
             <h1 className="site-title">Costa Rica Trip — Schedule</h1>
             <p className="site-subtitle">Bright, simple, and beachy ☀️🌴 Built from everyone's spreadsheet responses to help plan our week in paradise!</p>
           </div>
+          <p className="site-explainer">
+            These schedules were generated from everyone's activity preferences and are offered in three tabbed options.
+          </p>
           <div className="site-header__actions">
             <input
               className="input"
@@ -77,6 +81,13 @@ export default function App() {
               Print / Save PDF
             </button>
           </div>
+          <button
+            className="header-toggle"
+            onClick={() => setHeaderOpen(o => !o)}
+            aria-expanded={isHeaderOpen}
+          >
+            {isHeaderOpen ? "Hide" : "Show"} Info
+          </button>
         </header>
 
         <Tabs active={active} onChange={setActive} />

--- a/src/index.css
+++ b/src/index.css
@@ -32,16 +32,37 @@ body{
   border-bottom:1px solid var(--line);
   padding:16px 20px;
   margin: -28px -20px 18px;
+  max-height:500px;
+  overflow:hidden;
+  transition:max-height .3s ease;
+  position:relative;
 }
+.site-header.collapsed{max-height:60px;}
+.site-header.collapsed .site-explainer,
+.site-header.collapsed .site-header__actions{display:none;}
 .site-header__titles{display:flex; gap:10px; align-items:baseline; flex-wrap:wrap}
 .site-title{margin:0; font-size:26px; letter-spacing:.2px}
 .site-subtitle{margin:0; color:var(--muted); font-size:14px}
+.site-explainer{margin:10px 0 0; color:var(--muted); font-size:14px}
 .site-header__actions{margin-top:10px; display:flex; gap:10px; flex-wrap:wrap}
+.header-toggle{
+  position:absolute;
+  top:10px; right:16px;
+  background:none;
+  border:0;
+  padding:4px 8px;
+  font-weight:700;
+  cursor:pointer;
+}
 
 @media (max-width: 480px){
   .site-header{padding:12px 16px; margin:-28px -20px 12px;}
   .site-title{font-size:20px;}
   .site-subtitle{font-size:12px;}
+  .header-toggle{display:block;}
+}
+@media (min-width: 481px){
+  .header-toggle{display:none;}
 }
 
 .btn{


### PR DESCRIPTION
## Summary
- add explainer paragraph in site header
- introduce collapsible header with toggle for small screens
- style collapsed header and toggle button

## Testing
- `npx eslint .` (fails: 'motion' is defined but never used in existing components)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cd50103808333a8eb6001f0f415e2