### PR TITLE
Add general tips page and navigation entry

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,11 +4,12 @@ import AnimatedBackground from "./components/AnimatedBackground";
 import Tabs from "./components/Tabs";
 import OptionPanel from "./components/OptionPanel";
 import LandingPage from "./components/LandingPage";
+import TipsPage from "./components/TipsPage";
 import { D, E, F } from "./data/options";
 import { timeGuess } from "./utils/time";
 
 export default function App() {
-  const [entered, setEntered] = useState(false);
+  const [page, setPage] = useState("landing");
   const [active, setActive] = useState("F");
   const [compact, setCompact] = useState(false);
   const [q, setQ] = useState("");
@@ -53,8 +54,12 @@ export default function App() {
 
   const favCount = favs.size;
   
-  if (!entered) {
-    return <LandingPage onEnter={() => setEntered(true)} />;
+  if (page === "landing") {
+    return <LandingPage onEnter={() => setPage("main")} onShowTips={() => setPage("tips")} />;
+  }
+
+  if (page === "tips") {
+    return <TipsPage onBack={() => setPage("landing")} />;
   }
 
   return (

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -1,6 +1,6 @@
 import AnimatedBackground from "./AnimatedBackground";
 
-export default function LandingPage({ onEnter }) {
+export default function LandingPage({ onEnter, onShowTips }) {
   return (
     <>
       <AnimatedBackground />
@@ -13,6 +13,7 @@ export default function LandingPage({ onEnter }) {
           These schedules were generated from everyone's activity preferences and are offered in three tabbed options.
         </p>
         <button className="btn btn--primary" onClick={onEnter}>Enter</button>
+        <button className="btn" onClick={onShowTips}>General Tips & Coordination</button>
       </div>
     </>
   );

--- a/src/components/TipsPage.jsx
+++ b/src/components/TipsPage.jsx
@@ -1,0 +1,18 @@
+import AnimatedBackground from "./AnimatedBackground";
+
+export default function TipsPage({ onBack }) {
+  return (
+    <>
+      <AnimatedBackground />
+      <div className="landing">
+        <h1 className="site-title">General Tips & Coordination</h1>
+        <p>Use this space to share general trip tips and coordination notes.</p>
+        <ul>
+          <li>Placeholder tip one.</li>
+          <li>Placeholder tip two.</li>
+        </ul>
+        <button className="btn" onClick={onBack}>Back</button>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add TipsPage with placeholder content and back button
- wire App to show tips and landing/main pages via `page` state
- add Tips button on landing page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cde2c38a48333b6ce2f326a048ad2