### PR TITLE
Refactor landing page intro list layout

### DIFF
--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -12,11 +12,11 @@ export default function LandingPage({ onEnter, onShowTips, onShowRules }) {
           <p className="lead">
             Welcome! This mini-site has everything we need for a smooth trip.
           </p>
-          <ul className="intro-list">
-            <li>🗓️ <strong>Activity Schedule</strong> — the day-by-day plan sent to the concierge.</li>
-            <li>🌴 <strong>Tips & Coordination</strong> — flights, money, rides, packing, and local basics.</li>
-            <li>🛡️ <strong>Rules & Expectations</strong> — safety guidelines and group norms so everyone has fun.</li>
-          </ul>
+          <div className="intro-list">
+            <p>🗓️ <strong>Activity Schedule</strong> — the day-by-day plan sent to the concierge.</p>
+            <p>🌴 <strong>Tips & Coordination</strong> — flights, money, rides, packing, and local basics.</p>
+            <p>🛡️ <strong>Rules & Expectations</strong> — safety guidelines and group norms so everyone has fun.</p>
+          </div>
         </div>
 
         <div className="btn-row">

--- a/src/index.css
+++ b/src/index.css
@@ -191,6 +191,16 @@ body.compact .days-grid{gap:12px}
   padding:40px 20px;
 }
 
+/* intro list */
+.intro-list{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  margin:0;
+  padding:0;
+}
+.intro-list p{margin:0;}
+
 /* NEW: horizontal button row on landing */
 .btn-row{
   display:flex;


### PR DESCRIPTION
## Summary
- Replace landing page intro list with bulletless flex-column div
- Add CSS to remove list styling and control spacing for intro items

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npx eslint src/components/LandingPage.jsx src/index.css`

------
https://chatgpt.com/codex/tasks/task_e_689cecda23548333b17faf4e520e61fc