### PR TITLE
Enlarge roster sign-up display

### DIFF
--- a/src/components/SignupPage.jsx
+++ b/src/components/SignupPage.jsx
@@ -381,7 +381,9 @@ export default function SignupPage({ onBack }) {
                         <div key={idx} className="day__item">
                           <div className="day__item-main">
                             <span className="day__item-name">{it.name}</span>
-                            <span className="badge">{people.length}</span>
+                            <span className="signup-count">
+                              (People Signed up = {people.length})
+                            </span>
                           </div>
                           {people.length > 0 && (
                             <div className="day__item-preferred roster-names">

--- a/src/index.css
+++ b/src/index.css
@@ -118,7 +118,7 @@ body{
   color:#063; border-radius:999px; padding:6px 8px;
 }
 .day__item-preferred{margin-top:6px; font-size:12px; color:var(--muted)}
-.roster-names{font-size:14px; font-weight:600}
+.roster-names{font-size:24px; font-weight:600}
 
 /* compact mode */
 body.compact .day__item{padding:8px 10px}
@@ -166,6 +166,11 @@ body.compact .days-grid{gap:12px}
   font-weight:800;
   vertical-align:middle;
   margin-left:6px;
+}
+
+.signup-count{
+  font-size:24px;
+  font-weight:700;
 }
 
 /* landing */


### PR DESCRIPTION
## Summary
- Replace numeric badge with explicit "People Signed up = X" text in roster
- Amplify roster name and sign-up count font sizes for better visibility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de15561888333abc50e6151e0193d